### PR TITLE
kernel: crypto: add kmod-crypto-chacha20poly1305

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -101,6 +101,18 @@ endef
 $(eval $(call KernelPackage,crypto-ccm))
 
 
+define KernelPackage/crypto-chacha20poly1305
+  TITLE:=ChaCha20-Poly1305 AEAD support, RFC7539 (used by strongSwan IPsec VPN)
+  DEPENDS:=+kmod-crypto-aead +kmod-crypto-manager
+  KCONFIG:=CONFIG_CRYPTO_CHACHA20POLY1305
+  FILES:=$(LINUX_DIR)/crypto/chacha20poly1305.ko
+  AUTOLOAD:=$(call AutoLoad,09,chacha20poly1305)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-chacha20poly1305))
+
+
 define KernelPackage/crypto-cmac
   TITLE:=Support for Cipher-based Message Authentication Code (CMAC)
   DEPENDS:=+kmod-crypto-hash


### PR DESCRIPTION
此修改可以解决在编译时提示的 strongswan 缺少依赖模块 kmod-crypto-chacha20poly1305 的问题。

以下是作者 @xwang1498 碰到的问题以及参与的问题讨论：
https://github.com/openwrt/openwrt/pull/9951
https://github.com/openwrt/packages/issues/18192
