### PR TITLE
change immortalwrt repo

### DIFF
--- a/include/version.mk
+++ b/include/version.mk
@@ -29,7 +29,7 @@ VERSION_CODE:=$(call qstrip,$(CONFIG_VERSION_CODE))
 VERSION_CODE:=$(if $(VERSION_CODE),$(VERSION_CODE),$(REVISION))
 
 VERSION_REPO:=$(call qstrip,$(CONFIG_VERSION_REPO))
-VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),https://downloads.openwrt.org/snapshots)
+VERSION_REPO:=$(if $(VERSION_REPO),$(VERSION_REPO),https://downloads.immortalwrt.org/releases/18.06-k5.4-SNAPSHOT)
 
 VERSION_DIST:=$(call qstrip,$(CONFIG_VERSION_DIST))
 VERSION_DIST:=$(if $(VERSION_DIST),$(VERSION_DIST),ImmortalWrt)

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -183,7 +183,7 @@ if VERSIONOPT
 	config VERSION_REPO
 		string
 		prompt "Release repository"
-		default "https://downloads.openwrt.org/snapshots"
+		default "https://downloads.immortalwrt.org/releases/18.06-k5.4-SNAPSHOT"
 		help
 			This is the repository address embedded in the image, it defaults
 			to the trunk snapshot repo; the url may contain the following placeholders:

--- a/package/emortal/default-settings/files/99-default-settings
+++ b/package/emortal/default-settings/files/99-default-settings
@@ -13,7 +13,6 @@ rm -f /usr/lib/lua/luci/view/admin_status/index/minidlna.htm
 
 ln -sf /sbin/ip /usr/bin/ip
 
-sed -i '/immortalwrt_luci/ { s/snapshots/releases\/18.06.9/g; }'  /etc/opkg/distfeeds.conf
 sed -i "s/# //g" /etc/opkg/distfeeds.conf
 
 sed -i 's/root::0:0:99999:7:::/root:$1$V4UetPzk$CYXluq4wUazHjmCDBCqXF.:0:0:99999:7:::/g' /etc/shadow

--- a/package/emortal/default-settings/files/99-default-settings-chinese
+++ b/package/emortal/default-settings/files/99-default-settings-chinese
@@ -12,6 +12,6 @@ uci -q batch <<-EOF
 EOF
 uci commit system
 
-sed -i 's,downloads.openwrt.org,mirrors.tencent.com/lede,g' /etc/opkg/distfeeds.conf
+sed -i 's,downloads.immortalwrt.org,mirrors.vsean.net/openwrt,g' /etc/opkg/distfeeds.conf
 
 exit 0

--- a/package/emortal/default-settings/files/99-default-settings-chinese
+++ b/package/emortal/default-settings/files/99-default-settings-chinese
@@ -6,7 +6,7 @@ uci -q batch <<-EOF
 
 	delete system.ntp.server
 	add_list system.ntp.server='ntp.tencent.com'
-	add_list system.ntp.server='ntp.aliyun.com'
+	add_list system.ntp.server='ntp1.aliyun.com'
 	add_list system.ntp.server='ntp.ntsc.ac.cn'
 	add_list system.ntp.server='cn.ntp.org.cn'
 EOF


### PR DESCRIPTION
换回immortalwrt软件源，解决openwrt snapshot软件源安装的ddns脚本无法正常使用的问题

有可能会跳kmod不认内核的警告，自编译通病，能装上一般可以直接无视

```
Configuring ddns-scripts.
Configuring luci-app-ddns.
Configuring luci-i18n-ddns-zh-cn.
Collected errors:
 * pkg_hash_check_unresolved: cannot find dependency kernel (= 5.4.203-1-aa6246d6bd208b43e7f1e1f1f51b62a2) for kmod-crypto-hash
 * pkg_hash_check_unresolved: cannot find dependency kernel (= 5.4.203-1-aa6246d6bd208b43e7f1e1f1f51b62a2) for kmod-crypto-null
 * pkg_hash_check_unresolved: cannot find dependency kernel (= 5.4.203-1-aa6246d6bd208b43e7f1e1f1f51b62a2) for kmod-crypto-aead
 * pkg_hash_check_unresolved: cannot find dependency kernel (= 5.4.203-1-aa6246d6bd208b43e7f1e1f1f51b62a2) for kmod-crypto-manager
 * pkg_hash_check_unresolved: cannot find dependency kernel (= 5.4.203-1-aa6246d6bd208b43e7f1e1f1f51b62a2) for kmod-crypto-user
 * pkg_hash_check_unresolved: cannot find dependency kernel (= 5.4.203-1-aa6246d6bd208b43e7f1e1f1f51b62a2) for kmod-crypto-authenc
 * pkg_hash_check_unresolved: cannot find dependency kernel (= 5.4.203-1-aa6246d6bd208b43e7f1e1f1f51b62a2) for kmod-cryptodev
```