### PR TITLE
adjust processor affinity, fix build error

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -831,10 +831,6 @@ sub update {
 		};
 	}
 
-	if ($failed == 0) {
-		system(`sed -i -e 's/"^rausb%d", "^rai%d", "^ra%d", "^wdsi%d", "^wds%d", "^apclii%d", "^apcli%d", "^apcliusb%d", //' feeds/luci/modules/luci-base/luasrc/model/network.lua`);
-	}
-
 	refresh_config();
 
 	return $failed;

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/set-irq-affinity
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/set-irq-affinity
@@ -16,6 +16,10 @@ start() {
 		[ $mask = 4 ] && mask=8
 	done
 
+	for iface in $(ls /sys/class/net); do
+		echo 6 > /sys/class/net/$iface/queues/rx-0/rps_cpus
+	done
+
 	modprobe mt_wifi
 	ifconfig rax0 up
 	ifconfig ra0 up
@@ -25,16 +29,4 @@ start() {
 	ifconfig apclii0 up
 	/etc/init.d/apcli.sh start
 	modprobe mtkhnat
-
-	for eth in /sys/class/net/eth[0-9]*; do
-		echo 6 > $eth/queues/rx-0/rps_cpus
-	done
-
-	echo "6" > "/sys/class/net/ra0/queues/rx-0/rps_cpus"
- 	echo "6" > "/sys/class/net/rai0/queues/rx-0/rps_cpus"
- 	echo "6" > "/sys/class/net/rax0/queues/rx-0/rps_cpus"
- 	echo "6" > "/sys/class/net/apcli0/queues/rx-0/rps_cpus"
- 	echo "6" > "/sys/class/net/apclix0/queues/rx-0/rps_cpus"
- 	echo "6" > "/sys/class/net/apclii0/queues/rx-0/rps_cpus"
-	
 }


### PR DESCRIPTION
- some device (like cr660x) doesn't have `ra0`, `rai0`, `rax0`, `apcli0`, `apclix0`, `apclii0` 
`/etc/rc.d/S99set-irq-affinity: /etc/rc.common: line 36: can't create /sys/class/net/apcli0/queues/rx-0/rps_cpus: nonexistent directory`


- fix build error
   > Need review: cause https://github.com/padavanonly/immortalwrt/issues/17.
   > _Originally posted by @dirname in https://github.com/padavanonly/immortalwrt/pull/7#discussion_r999972707_