### PR TITLE
fix set-irq-affinity

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/init.d/set-irq-affinity
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/set-irq-affinity
@@ -24,10 +24,10 @@ start() {
 	ifconfig rax0 up
 	ifconfig ra0 up
 	ifconfig rai0 up
-	ifconfig apclix0 up
-	ifconfig apcli0 up
-	ifconfig apclii0 up
-	/etc/init.d/apcli.sh start
+#ifconfig apclix0 up
+#ifconfig apcli0 up
+#ifconfig apclii0 up
+#/etc/init.d/apcli.sh start
 	modprobe mtkhnat
 	echo 32768 > /proc/sys/net/netfilter/nf_conntrack_buckets
 	echo 16384 > /proc/sys/net/netfilter/nf_conntrack_expect_max


### PR DESCRIPTION
脚本会导致无线中继处于常开状态，即使未设置中继或手动断开中继，设备重启后仍然会处于开启状态并不停搜索不存在的中继ID。
这将导致连接的无线设备异常，断流。
个人水平有限，暂时注释处理。注释后不影响中继设置，如需要中继功能，去掉注释即可。